### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/src/Nova/Zipcode.php
+++ b/src/Nova/Zipcode.php
@@ -15,7 +15,7 @@ class Zipcode extends Field
      */
     public $component = 'zipcode';
 
-    public function __construct($name, $zipcode_placeholder, $house_number_placeholder, $field_connections = [], callable $resolveCallback = null)
+    public function __construct($name, $zipcode_placeholder, $house_number_placeholder, $field_connections = [], ?callable $resolveCallback = null)
     {
         $this->name = $name;
         $this->zipcode_placeholder = $zipcode_placeholder;

--- a/src/Zipcode.php
+++ b/src/Zipcode.php
@@ -22,7 +22,7 @@ class Zipcode
 
     protected $flexible_id_prefix = null;
 
-    public function get(string $zip_code, string $house_number = null)
+    public function get(string $zip_code, ?string $house_number = null)
     {
         $response_array = $this->callGeoDataApi($zip_code, $house_number);
         $this->validateApiResponse($response_array);
@@ -71,7 +71,7 @@ class Zipcode
         }
     }
 
-    protected function callGeoDataApi(string $zip_code, string $house_number = null)
+    protected function callGeoDataApi(string $zip_code, ?string $house_number = null)
     {
         $zip_code = str_replace(' ', '', $zip_code);
         $url = "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free?fq=postcode:{$zip_code}";
@@ -87,7 +87,7 @@ class Zipcode
         throw new Exception(__('The National Geo Register is down at the moment.'), 2);
     }
 
-    public function flexibleIdPrefix(string $flexible_id_prefix = null): self
+    public function flexibleIdPrefix(?string $flexible_id_prefix = null): self
     {
         $this->flexible_id_prefix = ($flexible_id_prefix !== 'null') ? $flexible_id_prefix : null;
         return $this;


### PR DESCRIPTION
## Summary
- Fixed PHP 8.4 deprecation warnings for implicit nullable parameters
- Added explicit nullable type declarations (`?`) to parameters with `null` default values
- Ensures compatibility with PHP 8.4

## Changes
- `src/Nova/Zipcode.php`: Added `?callable` to `$resolveCallback` parameter
- `src/Zipcode.php`: Added `?string` to:
  - `$house_number` parameter in `get()` method
  - `$house_number` parameter in `callGeoDataApi()` method
  - `$flexible_id_prefix` parameter in `flexibleIdPrefix()` method

## Test plan
- [x] Syntax validation passed for all modified files
- [x] No additional PHP 8.4 deprecation issues found in codebase

Fixes #35

🤖 Generated with [Claude Code](https://claude.ai/code)